### PR TITLE
Update workflow to use prod branch

### DIFF
--- a/.github/BRANCH_STRATEGY.md
+++ b/.github/BRANCH_STRATEGY.md
@@ -1,0 +1,69 @@
+# Branch Strategy
+
+## Summary
+
+- **prod** is the release branch and is heavily protected. No direct pushes. Changes land only via pull requests with required reviews and status checks.
+- **dev** is the default development branch. All feature work branches from dev and merges back into dev via pull requests.
+- **Feature branches** use descriptive prefixes such as `update`, `fix`, `docs`, `chore`. Example: `update/update-branch-naming`.
+
+## Backup and Tagging
+
+- The weekly-backup workflow defaults to backing up **prod** via `BRANCH_TO_BACKUP: 'prod'`.
+- The composite action input `branch-to-backup` defaults to **prod**. It can be overridden for manual runs.
+- Backup branches are named using the `backup-prefix` input and a date stamp. Example: `backup-YYYY-MM-DD`.
+- The action creates annotated tags with commit statistics and metadata for traceability.
+
+## Day-to-day Development Flow
+
+1. Create feature branch from **dev**.
+2. Commit work to the feature branch.
+3. Open a pull request targeting **dev**.
+4. Ensure required checks pass. Merge into **dev**.
+
+## Release Flow
+
+1. Cut a release pull request from **dev** to **prod**.
+2. Ensure all required checks and approvals are satisfied.
+3. Merge into **prod**.
+4. The scheduled backup will back up **prod** automatically. Manual dispatch can be used if needed.
+
+## Branch Protections
+
+### prod
+- Require pull request reviews and status checks to pass.
+- Restrict who can push. Direct pushes are disabled.
+- Consider enabling linear history and signed commits.
+
+### dev
+- Default branch. Require status checks to pass.
+- Pull requests required for merging changes.
+- Direct pushes may be restricted according to team policy.
+
+## Naming Conventions
+
+- **Feature branches**: `update`, `fix`, `docs`, `chore` prefixes.
+- **Backup branches**: `backup-YYYY-MM-DD`.
+- **Tags**: Annotated tags with release or backup metadata.
+
+## Example Commands
+
+```bash
+# Start a feature branch
+git checkout dev && git pull --ff-only && git checkout -b update/update-branch-naming
+
+# Push your feature
+git push -u origin update/update-branch-naming
+
+# Open a PR: target the dev branch
+gh pr create -B dev
+
+# Release PR: from dev to prod with required approvals and checks
+gh pr create -H dev -B prod
+```
+
+## Local Testing Notes
+
+- The composite action defaults to **prod**. For ad-hoc tests, override `branch-to-backup` to a temporary branch.
+- If using `act`, ensure any sample event inputs use **prod** by default to match this strategy.
+
+This strategy aligns the default backup target with the protected **prod** branch while keeping **dev** as the base for active development.

--- a/.github/workflows/weekly-backup.yml
+++ b/.github/workflows/weekly-backup.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   BACKUP_PREFIX: 'backup'
-  BRANCH_TO_BACKUP: 'main'
+  BRANCH_TO_BACKUP: 'prod'
 
 jobs:
   backup:
@@ -41,98 +41,11 @@ jobs:
       issues: write # For failure notifications
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - name: Create weekly backup
+        uses: ./
         with:
-          fetch-depth: 0 # Fetch full history
-          ref: ${{ env.BRANCH_TO_BACKUP }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Create backup branch
-        id: backup
-        run: |
-          set -e # Exit on any error
-          
-          BACKUP_DATE=$(date -u +"%Y-%m-%d")
-          BACKUP_BRANCH="${BACKUP_PREFIX}-${BACKUP_DATE}"
-          COMMIT_SHA=$(git rev-parse HEAD)
-          
-          echo "branch=${BACKUP_BRANCH}" >> $GITHUB_OUTPUT
-          echo "commit=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-          echo "date=${BACKUP_DATE}" >> $GITHUB_OUTPUT
-
-          # Check if backup branch already exists
-          if git ls-remote --heads origin "${BACKUP_BRANCH}" | grep -q "${BACKUP_BRANCH}"; then
-            echo "status=skipped" >> $GITHUB_OUTPUT
-            echo "⏭️ Backup branch ${BACKUP_BRANCH} already exists"
-            exit 0
-          fi
-
-          # Create and push backup branch
-          git checkout -b "${BACKUP_BRANCH}"
-          git push origin "${BACKUP_BRANCH}"
-          
-          echo "status=created" >> $GITHUB_OUTPUT
-          echo "✅ Successfully created backup branch: ${BACKUP_BRANCH}"
-
-      - name: Create backup tag
-        if: steps.backup.outputs.status == 'created'
-        run: |
-          TAG_NAME="${{ steps.backup.outputs.branch }}"
-          
-          # Gather metadata
-          COMMITS_THIS_WEEK=$(git log --since='7 days ago' --oneline | wc -l)
-          CONTRIBUTORS=$(git log --since='7 days ago' --format='%an' | sort -u | wc -l)
-          FILES_CHANGED=$(git diff --name-only HEAD~${COMMITS_THIS_WEEK}..HEAD 2>/dev/null | wc -l || echo "0")
-          
-          # Create annotated tag
-          git tag -a "${TAG_NAME}" -m "Weekly Backup - ${{ steps.backup.outputs.date }}
-          
-          Repository: ${{ github.repository }}
-          Source Branch: ${{ env.BRANCH_TO_BACKUP }}
-          Commit: ${{ steps.backup.outputs.commit }}
-          Workflow Run: ${{ github.run_id }}
-          
-          Statistics (last 7 days):
-          - Commits: ${COMMITS_THIS_WEEK}
-          - Contributors: ${CONTRIBUTORS}
-          - Files Changed: ${FILES_CHANGED}
-          "
-          
-          git push origin "refs/tags/${TAG_NAME}"
-          echo "✅ Created backup tag with metadata"
-
-      - name: Create backup summary
-        if: always()
-        run: |
-          STATUS="${{ steps.backup.outputs.status }}"
-          BACKUP_BRANCH="${{ steps.backup.outputs.branch }}"
-          COMMIT_SHA="${{ steps.backup.outputs.commit }}"
-          
-          echo "## Weekly Backup Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "$STATUS" == "created" ]; then
-            echo "### ✅ Backup Created Successfully" >> $GITHUB_STEP_SUMMARY
-          elif [ "$STATUS" == "skipped" ]; then
-            echo "### ⏭️ Backup Already Exists" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### ❌ Backup Failed" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Details:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Date: \`${{ steps.backup.outputs.date }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Branch: \`${BACKUP_BRANCH}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Commit: \`${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Source: \`${{ env.BRANCH_TO_BACKUP }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "[View Backup Branch](https://github.com/${{ github.repository }}/tree/${BACKUP_BRANCH})" >> $GITHUB_STEP_SUMMARY
+          backup-prefix: ${{ env.BACKUP_PREFIX }}
+          branch-to-backup: ${{ env.BRANCH_TO_BACKUP }}
 
       - name: Create failure issue
         if: failure()

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   branch-to-backup:
     description: 'Branch to create backups from'
     required: false
-    default: 'main'
+    default: 'prod'
 
   github-token:
     description: 'GitHub token for repository access'


### PR DESCRIPTION
- Updates the weekly-backup workflow to use 'prod' as the default backup
target instead of 'main'
- Updates the action's default branch-to-backup input to 'prod' to align
with the protected branch strategy
- Adds comprehensive branch strategy documentation in
.github/BRANCH_STRATEGY.md
