### PR TITLE
security: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,87 @@
+# MIT License
+#
+# Copyright (c) 2025 Gareth Evans
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: OpenSSF Scorecard Supply Chain Security
+
+on:
+  # Run weekly on Sundays at 02:00 UTC
+  schedule:
+    - cron: '0 2 * * 0'
+  # Allow manual triggering
+  workflow_dispatch:
+  # Run on branch protection rule changes
+  branch_protection_rule:
+
+# Declare default permissions as read only
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard
+      security-events: write
+      # Needed to publish results and get a badge
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge
+          #   - See https://github.com/ossf/scorecard-action#publishing-results
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: Upload artifact
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional)
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8b2c5ca86dcb985 # v3.27.6
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Implements OpenSSF Scorecard for supply chain security assessment.

## Changes
- Adds weekly security scanning workflow using OpenSSF Scorecard
- Generates SARIF results for GitHub Code Scanning dashboard  
- Publishes results to OpenSSF REST API for public scorecard badge
- Uses pinned action versions with full commit SHAs for security
- Configures minimal permissions following security best practices

## Benefits
- Provides measurable security metrics for marketplace trust
- Identifies potential supply chain vulnerabilities automatically
- Enables repository security badge display
- Meets critical marketplace compliance requirements

## Testing
- Workflow can be manually triggered for immediate verification
- All action dependencies are pinned to secure commit SHAs
- Permissions are configured with least-privilege principle

Addresses critical TODO item for marketplace readiness.