### PR TITLE
fix(dependabot): replace invalid 'security-update' with valid update-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,13 @@ updates:
     # Group security updates for faster processing
     groups:
       security-updates:
+        applies-to: security-updates
         patterns:
           - "*"
         update-types:
-          - "security-update"
+          - "major"
+          - "minor"
+          - "patch"
       # Group patch updates to reduce PR noise
       patch-updates:
         patterns:


### PR DESCRIPTION
Fix Dependabot configuration syntax error by replacing invalid 'security-update' value with valid major/minor/patch update-types and adding proper applies-to scoping.